### PR TITLE
Refactoring Adamic Adar and adding a test

### DIFF
--- a/html/json-rpc-test.html
+++ b/html/json-rpc-test.html
@@ -144,7 +144,7 @@ dataType: "json",
 success: function(data) {whatever = data; $(".info").append("<p>" + JSON.stringify(data) + "</p>");}
 });
 
-data = {"jsonrpc": "2.0", "method": "adamic_adar_index", "params": {"source": 1, "strings": true, "include_neighbors": true}, "id": 14};
+data = {"jsonrpc": "2.0", "method": "adamic_adar_index", "params": {"source": 1, "strings": true}, "id": 14};
 jQuery.ajax({
 url: "http://localhost:8088/jsonrpc",
 type: "POST",

--- a/src/bin/clients/tools/CMakeLists.txt
+++ b/src/bin/clients/tools/CMakeLists.txt
@@ -9,17 +9,17 @@ SET(libdep_alg_to_mongo stinger_net mongo_c_driver)
 SET(libdep_dump_graph_to_disk stinger_net mongo_c_driver)
 
 IF(APPLE)
-  SET(libdep_json_rpc_server ${CMAKE_BINARY_DIR}/lib/libprotobuf.dylib stinger_net pthread mongoose)
+  SET(libdep_json_rpc_server ${CMAKE_BINARY_DIR}/lib/libprotobuf.dylib stinger_alg stinger_net pthread mongoose)
 ELSEIF(CYGWIN OR WIN32)
-  SET(libdep_json_rpc_server ${CMAKE_BINARY_DIR}/lib/libprotobuf.dll.a stinger_net pthread mongoose)
+  SET(libdep_json_rpc_server ${CMAKE_BINARY_DIR}/lib/libprotobuf.dll.a stinger_alg stinger_net pthread mongoose)
 ELSE()
-  SET(libdep_json_rpc_server ${CMAKE_BINARY_DIR}/lib/libprotobuf.so stinger_net pthread mongoose)
+  SET(libdep_json_rpc_server ${CMAKE_BINARY_DIR}/lib/libprotobuf.so stinger_alg stinger_net pthread mongoose)
 ENDIF()
 
 SET(tgtdep_default stinger_core stinger_utils rt)
 SET(tgtdep_alg_data_to_json protobuf stinger_net)
 SET(tgtdep_web_server string rapidjson mongoose kv_store)
-SET(tgtdep_json_rpc_server rapidjson)
+SET(tgtdep_json_rpc_server rapidjson stinger_alg)
 SET(tgtdep_sql_client stinger_net)
 
 #################################################################

--- a/src/bin/clients/tools/json_rpc_server/src/adamic_adar.cpp
+++ b/src/bin/clients/tools/json_rpc_server/src/adamic_adar.cpp
@@ -6,28 +6,22 @@
 
 #define LOG_AT_W  /* warning only */
 #include "stinger_core/stinger_error.h"
+extern "C" {
+#include "stinger_alg/adamic_adar.h"
+}
 
 using namespace gt::stinger;
-
-
-static int
-compare (const void * a, const void * b)
-{
-    return ( *(int*)a - *(int*)b );
-}
 
 int64_t 
 JSON_RPC_adamic_adar::operator()(rapidjson::Value * params, rapidjson::Value & result, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> & allocator)
 {
   int64_t source;
   bool strings;
-  bool include_neighbors;
   int64_t etype;
 
   rpc_params_t p[] = {
     {"source", TYPE_VERTEX, &source, false, 0},
     {"strings", TYPE_BOOL, &strings, true, 0},
-    {"include_neighbors", TYPE_BOOL, &include_neighbors, true, 0},
     {"etype", TYPE_EDGE_TYPE , &etype, true, -1},
     {NULL, TYPE_NONE, NULL, false, 0}
   };
@@ -48,9 +42,6 @@ JSON_RPC_adamic_adar::operator()(rapidjson::Value * params, rapidjson::Value & r
   rapidjson::Value vtx_str (rapidjson::kArrayType);
   rapidjson::Value vtx_val (rapidjson::kArrayType);
 
-
-  int64_t source_deg = stinger_outdegree (S, source);
-
   /* this part of the response needs to be set no matter what */
   src.SetInt64(source);
   result.AddMember("source", src, allocator);
@@ -65,184 +56,28 @@ JSON_RPC_adamic_adar::operator()(rapidjson::Value * params, rapidjson::Value & r
     result.AddMember("source_str", src_str, allocator);
   }
 
-  /* vertex has no edges -- this is easy */
-  if (source_deg == 0) {
-    result.AddMember("vertex_id", vtx_id, allocator);
-    if (strings)
-      result.AddMember("vertex_str", vtx_str, allocator);
-    result.AddMember("value", vtx_val, allocator);
-    return 0;
-  }
+  int64_t * candidates = NULL;
+  double * scores = NULL;
 
-  int64_t * source_adj = (int64_t *) xmalloc (source_deg * sizeof(int64_t));
+  int64_t num_candidates = adamic_adar(S, source, etype, &candidates, &scores);
 
-  /* extract and sort the neighborhood of SOURCE */
-  size_t res;
-  if (etype == -1) {
-    stinger_gather_successors (S, source, &res, source_adj, NULL, NULL, NULL, NULL, source_deg);
-  } else {
-    stinger_gather_typed_successors (S, etype, source, &res, source_adj, source_deg);
-    source_deg = res;
-  }
-  qsort (source_adj, source_deg, sizeof(int64_t), compare);
-
-  /* create a marks array to unique-ify the vertex list */
-  uint64_t max_nv = S->max_nv;
-  int64_t * marks = (int64_t *) xmalloc (max_nv * sizeof(int64_t));
-
-  for (int64_t i = 0; i < max_nv; i++) {
-    marks[i] = 0;
-  }
-  marks[source] = 1;
-
-  /* calculate the maximum number of vertices in the two-hop neighborhood */
-  int64_t two_hop_size = 0;
-  for (int64_t i = 0; i < source_deg; i++) {
-    int64_t v = source_adj[i];
-    int64_t v_deg = stinger_outdegree(S, v);
-    marks[v] = 1;
-    two_hop_size += v_deg;
-  }
-
-  /* put everyone in the two hop neighborhood in a list (only once) */
-  int64_t head = 0;
-  int64_t * two_hop_neighborhood = (int64_t *) xmalloc (two_hop_size * sizeof(int64_t));
-
-  for (int64_t i = 0; i < source_deg; i++) {
-    int64_t v = source_adj[i];
-    STINGER_FORALL_EDGES_OF_VTX_BEGIN(S,v) {
-      if (stinger_int64_fetch_add(&marks[STINGER_EDGE_DEST], 1) == 0) {
-	int64_t loc = stinger_int64_fetch_add(&head, 1);
-	two_hop_neighborhood[loc] = STINGER_EDGE_DEST;
-      }
-    } STINGER_FORALL_EDGES_OF_VTX_END();
-  }
-
-  /* sanity check */
-  if (head > two_hop_size) {
-    LOG_W ("over ran the buffer");
-  }
-  two_hop_size = head;  // limit the computation later
-
-  /* calculate the Adamic-Adar score for each vertex in level 1 */
-  if (include_neighbors) {
-    for (int64_t k = 0; k < source_deg; k++) {
-      double adamic_adar_score = 0.0;
-      int64_t vtx = source_adj[k];
-      int64_t v_deg = stinger_outdegree(S, vtx);
-
-      int64_t * target_adj = (int64_t *) xmalloc (v_deg * sizeof(int64_t));
-      size_t res;
-      if (etype == -1) {
-	stinger_gather_successors (S, vtx, &res, target_adj, NULL, NULL, NULL, NULL, v_deg);
-      } else {
-	stinger_gather_typed_successors (S, etype, vtx, &res, target_adj, v_deg);
-	v_deg = res;
-      }
-      qsort (target_adj, v_deg, sizeof(int64_t), compare);
-
-      int64_t i = 0, j = 0;
-      while (i < source_deg && j < v_deg)
-      {
-	if (source_adj[i] < target_adj[j]) {
-	  i++;
-	}
-	else if (target_adj[j] < source_adj[i]) {
-	  j++;
-	}
-	else /* if source_adj[i] == target_adj[j] */
-	{
-	  int64_t neighbor = source_adj[i];
-	  int64_t my_deg = stinger_outdegree(S, neighbor);
-	  double score = 1.0 / log ((double) my_deg);
-	  adamic_adar_score += score;
-	  i++;
-	  j++;
-	}
-      }
-
-      free (target_adj);
-
-      /* adamic_adar_score done for (source, vtx) */
-      name.SetInt64(vtx);
-      vtx_id.PushBack(name, allocator);
-      if (strings) {
-	char * physID;
-	uint64_t len;
-	if(-1 == stinger_mapping_physid_direct(S, vtx, &physID, &len)) {
-	  physID = (char *) "";
-	  len = 0;
-	}
-	vtx_phys.SetString(physID, len, allocator);
-	vtx_str.PushBack(vtx_phys, allocator);
-      }
-      value.SetDouble(adamic_adar_score);
-      vtx_val.PushBack(value, allocator);
-
-    }
-  }
-
-  /* calculate the Adamic-Adar score for each vertex in level 2 */
-  for (int64_t k = 0; k < two_hop_size; k++) {
-    double adamic_adar_score = 0.0;
-    int64_t vtx = two_hop_neighborhood[k];
-    int64_t v_deg = stinger_outdegree(S, vtx);
-
-    int64_t * target_adj = (int64_t *) xmalloc (v_deg * sizeof(int64_t));
-    size_t res;
-    if (etype == -1) {
-      stinger_gather_successors (S, vtx, &res, target_adj, NULL, NULL, NULL, NULL, v_deg);
-    } else {
-      stinger_gather_typed_successors (S, etype, vtx, &res, target_adj, v_deg);
-      v_deg = res;
-    }
-    qsort (target_adj, v_deg, sizeof(int64_t), compare);
-
-    int64_t i = 0, j = 0;
-    while (i < source_deg && j < v_deg)
-    {
-      if (source_adj[i] < target_adj[j]) {
-	i++;
-      }
-      else if (target_adj[j] < source_adj[i]) {
-	j++;
-      }
-      else /* if source_adj[i] == target_adj[j] */
-      {
-	int64_t neighbor = source_adj[i];
-	int64_t my_deg = stinger_outdegree(S, neighbor);
-	double score = 1.0 / log ((double) my_deg);
-	adamic_adar_score += score;
-	i++;
-	j++;
-      }
-    }
-
-    free (target_adj);
-
-    /* adamic_adar_score done for (source, vtx) */
-    name.SetInt64(vtx);
+  for (int64_t i = 0; i < num_candidates; i++) {
+    name.SetInt64(candidates[i]);
     vtx_id.PushBack(name, allocator);
     if (strings) {
       char * physID;
       uint64_t len;
-      if(-1 == stinger_mapping_physid_direct(S, vtx, &physID, &len)) {
-	physID = (char *) "";
-	len = 0;
+      if(-1 == stinger_mapping_physid_direct(S, candidates[i], &physID, &len)) {
+        physID = (char *) "";
+        len = 0;
       }
       vtx_phys.SetString(physID, len, allocator);
       vtx_str.PushBack(vtx_phys, allocator);
     }
-    value.SetDouble(adamic_adar_score);
+    value.SetDouble(scores[i]);
     vtx_val.PushBack(value, allocator);
   }
 
-  /* done with computation, free memory */
-  free (source_adj);
-  free (marks);
-  free (two_hop_neighborhood);
- 
-  /* configure the response */
   result.AddMember("vertex_id", vtx_id, allocator);
   if (strings)
     result.AddMember("vertex_str", vtx_str, allocator);

--- a/src/bin/clients/tools/json_rpc_server/src/adamic_adar.cpp
+++ b/src/bin/clients/tools/json_rpc_server/src/adamic_adar.cpp
@@ -83,5 +83,13 @@ JSON_RPC_adamic_adar::operator()(rapidjson::Value * params, rapidjson::Value & r
     result.AddMember("vertex_str", vtx_str, allocator);
   result.AddMember("value", vtx_val, allocator);
 
+  if (candidates != NULL) {
+    xfree(candidates);
+  }
+
+  if (scores != NULL) {
+    xfree(scores);
+  }
+
   return 0;
 }

--- a/src/bin/clients/tools/json_rpc_server/src/adamic_adar.cpp
+++ b/src/bin/clients/tools/json_rpc_server/src/adamic_adar.cpp
@@ -6,9 +6,7 @@
 
 #define LOG_AT_W  /* warning only */
 #include "stinger_core/stinger_error.h"
-extern "C" {
 #include "stinger_alg/adamic_adar.h"
-}
 
 using namespace gt::stinger;
 

--- a/src/bin/tests/CMakeLists.txt
+++ b/src/bin/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ include(ExternalProject)
 SET(libdep_default int_hm_seq int_ht_seq stinger_core stinger_utils string)
 SET(libdep_depold_community int_hm_seq int_ht_seq)
 SET(libdep_pagerank_test stinger_alg)
+SET(libdep_adamic_adar_test stinger_alg)
 
 IF(APPLE)
   SET(libdep_protobuf_test ${CMAKE_BINARY_DIR}/lib/libprotobuf.dylib)
@@ -18,6 +19,7 @@ SET(tgtdep_default int_hm_seq int_ht_seq stinger_core stinger_utils rt string)
 SET(tgtdep_protobuf_test protobuf)
 SET(tgtdep_depold_community int_hm_seq int_ht_seq)
 SET(tgtdep_pagerank_test stinger_alg)
+SET(tgtdep_adamic_adar_test stinger_alg)
 
 #################################################################
 # Iterate over each project and build appropriately based on type

--- a/src/bin/tests/adamic_adar_test/adamic_adar_test.c
+++ b/src/bin/tests/adamic_adar_test/adamic_adar_test.c
@@ -1,0 +1,85 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "stinger_alg/adamic_adar.h"
+#include "stinger_core/stinger.h"
+#include "stinger_core/stinger_shared.h"
+#include "stinger_alg/rmat.h"
+#include "stinger_utils/timer.h"
+
+#define NUM_EDGES (1 << 16)
+
+int main(int argc, char * argv[]) {
+  struct stinger * S = stinger_new_full(1<<13, 1<<16, 2, 2);
+
+  int64_t i, j;
+  int64_t scale = 0;
+  int64_t nv = stinger_max_nv(S);
+
+  int64_t tmp_nv = nv;
+  while (tmp_nv >>= 1) ++scale;
+
+  fprintf(stderr,"nv: %ld\n",nv);
+
+  double a = 0.55;
+  double b = 0.15;
+  double c = 0.15;
+  double d = 0.25;
+
+  dxor128_env_t env;
+  dxor128_seed(&env, 0);
+
+  fprintf(stderr,"Adding edges...");
+
+  OMP("omp parallel for")
+  for (int64_t z=0; z < NUM_EDGES; z++) {
+    rmat_edge (&i, &j, scale, a, b, c, d, &env);
+
+    stinger_insert_edge_pair(S, 1, i, j, 1, 1);
+  }
+
+  fprintf(stderr,"Done.\n");
+
+  fprintf(stderr,"Adamic Adar...\n");
+
+  double total_time = 0.0;
+  double epoch_time = 0.0;
+  double algorithm_time = 0.0;
+  
+  FILE * fp = fopen("adamic.csv", "w");
+
+  fprintf(fp,"Vertex,Outdegree,num_candidates,time (s)\n");
+
+  for (int64_t z=0; z < nv; z++) {
+    int64_t * candidates = NULL;
+    double * scores = NULL;
+
+    tic();
+
+    int64_t num_candidates = adamic_adar(S, z, -1, &candidates, &scores);
+
+    algorithm_time = toc();
+
+    fprintf(fp,"%ld,%ld,%ld,%lf\n",z,stinger_outdegree(S,z),num_candidates,algorithm_time);
+
+    total_time += algorithm_time;
+    epoch_time += algorithm_time;
+
+    if (z != 0 && z % 1000 == 0) {
+      fprintf(stderr,"%ld vertices in Total %lf (%lf s last 1000)\n",z,total_time,epoch_time);
+      epoch_time = 0.0;
+    }
+
+    if (candidates != NULL) {
+      xfree(candidates);
+    }
+    if (scores != NULL) {
+      xfree(scores);
+    }
+  }
+
+  fclose(fp);
+
+  fprintf(stderr,"Done.\n");
+
+  fprintf(stderr,"\nTime: %lf s\n",total_time);
+}

--- a/src/lib/stinger_alg/inc/adamic_adar.h
+++ b/src/lib/stinger_alg/inc/adamic_adar.h
@@ -1,0 +1,10 @@
+#ifndef STINGER_ADAMIC_ADAR_H
+#define STINGER_ADAMIC_ADAR_H
+
+#include "stinger_core/stinger_atomics.h"
+#include "stinger_core/stinger.h"
+#include "stinger_core/xmalloc.h"
+
+int64_t adamic_adar(const stinger_t * S, int64_t source, int64_t etype, int64_t ** candidates, double ** scores);
+
+#endif

--- a/src/lib/stinger_alg/inc/adamic_adar.h
+++ b/src/lib/stinger_alg/inc/adamic_adar.h
@@ -5,6 +5,15 @@
 #include "stinger_core/stinger.h"
 #include "stinger_core/xmalloc.h"
 
+#ifdef __cplusplus
+#define restrict
+extern "C" {
+#endif
+
 int64_t adamic_adar(const stinger_t * S, int64_t source, int64_t etype, int64_t ** candidates, double ** scores);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/lib/stinger_alg/src/adamic_adar.c
+++ b/src/lib/stinger_alg/src/adamic_adar.c
@@ -1,0 +1,138 @@
+#include "adamic_adar.h"
+#include "stinger_core/stinger_error.h"
+
+static int
+compare (const void * a, const void * b)
+{
+    return ( *(int*)a - *(int*)b );
+}
+
+int64_t adamic_adar(const stinger_t * S, int64_t source, int64_t etype, int64_t ** candidates, double ** scores) {
+  if (*candidates != NULL || *scores != NULL) {
+    LOG_E("Adamic Adar output arrays should not be allocated before call.  Possible memory leak.");
+  }
+
+  int64_t * output_vertices = NULL;
+  double * output_scores = NULL;
+
+  int64_t source_deg = stinger_outdegree (S, source);
+
+  /* Initialize to NULL in case of error */
+  *candidates = output_vertices;
+  *scores = output_scores;
+
+  /* vertex has no edges -- this is easy */
+  if (source_deg == 0) {
+    return 0;
+  }
+
+  int64_t * source_adj = (int64_t *) xmalloc (source_deg * sizeof(int64_t));
+
+  /* extract and sort the neighborhood of SOURCE */
+  size_t res;
+  if (etype == -1) {
+    stinger_gather_successors (S, source, &res, source_adj, NULL, NULL, NULL, NULL, source_deg);
+  } else {
+    stinger_gather_typed_successors (S, etype, source, &res, source_adj, source_deg);
+    source_deg = res;
+  }
+  qsort (source_adj, source_deg, sizeof(int64_t), compare);
+
+  /* create a marks array to unique-ify the vertex list */
+  uint64_t max_nv = S->max_nv;
+  int64_t * marks = (int64_t *) xmalloc (max_nv * sizeof(int64_t));
+
+  for (int64_t i = 0; i < max_nv; i++) {
+    marks[i] = 0;
+  }
+  marks[source] = 1;
+
+  /* calculate the maximum number of vertices in the two-hop neighborhood */
+  int64_t two_hop_size = 0;
+  for (int64_t i = 0; i < source_deg; i++) {
+    int64_t v = source_adj[i];
+    int64_t v_deg = stinger_outdegree(S, v);
+    marks[v] = 1;
+    two_hop_size += v_deg;
+  }
+
+
+  /* put everyone in the two hop neighborhood in a list (only once) */
+  int64_t head = 0;
+  int64_t * two_hop_neighborhood = (int64_t *) xmalloc (two_hop_size * sizeof(int64_t));
+
+  for (int64_t i = 0; i < source_deg; i++) {
+    int64_t v = source_adj[i];
+    STINGER_FORALL_EDGES_OF_VTX_BEGIN(S,v) {
+      if (stinger_int64_fetch_add(&marks[STINGER_EDGE_DEST], 1) == 0) {
+      	int64_t loc = stinger_int64_fetch_add(&head, 1);
+      	two_hop_neighborhood[loc] = STINGER_EDGE_DEST;
+      }
+    } STINGER_FORALL_EDGES_OF_VTX_END();
+  }
+
+  /* sanity check */
+  if (head > two_hop_size) {
+    LOG_W ("over ran the buffer");
+  }
+  two_hop_size = head;  // limit the computation later
+
+  /* Allocate output array */
+  output_vertices = (int64_t *) xmalloc (two_hop_size * sizeof(int64_t));
+  output_scores = (int64_t *) xmalloc (two_hop_size * sizeof(double));
+
+  /* calculate the Adamic-Adar score for each vertex in level 2 */
+  for (int64_t k = 0; k < two_hop_size; k++) {
+    double adamic_adar_score = 0.0;
+    int64_t vtx = two_hop_neighborhood[k];
+    int64_t v_deg = stinger_outdegree(S, vtx);
+
+    int64_t * target_adj = (int64_t *) xmalloc (v_deg * sizeof(int64_t));
+    size_t res;
+    if (etype == -1) {
+      stinger_gather_successors (S, vtx, &res, target_adj, NULL, NULL, NULL, NULL, v_deg);
+    } else {
+      stinger_gather_typed_successors (S, etype, vtx, &res, target_adj, v_deg);
+      v_deg = res;
+    }
+    qsort (target_adj, v_deg, sizeof(int64_t), compare);
+
+    int64_t i = 0, j = 0;
+    while (i < source_deg && j < v_deg)
+    {
+      if (source_adj[i] < target_adj[j]) {
+        i++;
+      }
+      else if (target_adj[j] < source_adj[i]) {
+        j++;
+      }
+      else /* if source_adj[i] == target_adj[j] */
+      {
+      	int64_t neighbor = source_adj[i];
+      	int64_t my_deg = stinger_outdegree(S, neighbor);
+        double score = 0.0;
+        if (my_deg > 1) {
+          score = 1.0 / log ((double) my_deg);
+        }
+      	adamic_adar_score += score;
+      	i++;
+      	j++;
+      }
+    }
+
+    free (target_adj);
+
+    output_vertices[k] = vtx;
+    output_scores[k] = adamic_adar_score;
+  }
+
+  /* Set output arrays */
+  *candidates = output_vertices;
+  *scores = output_scores;
+
+  /* done with computation, free memory */
+  free (source_adj);
+  free (marks);
+  free (two_hop_neighborhood);
+  return two_hop_size;
+}


### PR DESCRIPTION
Also I fixed divide by zero issues.  Adamic Adar only works on Undirected graphs.  For directed graphs, the divide by zero could occur, this is now guarded.

Performance results on my machine from the new test:
nv: 8192
Adding edges...Done.
Adamic Adar...
1000 vertices in Total 5.653540 (5.653540 s last 1000)
2000 vertices in Total 9.001196 (3.347656 s last 1000)
3000 vertices in Total 12.328701 (3.327505 s last 1000)
4000 vertices in Total 14.236971 (1.908270 s last 1000)
5000 vertices in Total 16.925649 (2.688678 s last 1000)
6000 vertices in Total 18.548048 (1.622398 s last 1000)
7000 vertices in Total 20.100395 (1.552348 s last 1000)
8000 vertices in Total 21.042004 (0.941609 s last 1000)
Done.

Time: 21.093368 s
