### PR TITLE
The x86_full_empty.c needs to be at Optimization -O0

### DIFF
--- a/lib/stinger_core/CMakeLists.txt
+++ b/lib/stinger_core/CMakeLists.txt
@@ -7,7 +7,6 @@ set(sources
 	src/stinger_physmap.c
 	src/stinger_shared.c
 	src/stinger_vertex.c
-	src/x86_full_empty.c
 	src/xmalloc.c
 )
 set(headers
@@ -25,6 +24,9 @@ set(headers
 	inc/x86_full_empty.h
 	inc/xmalloc.h
 )
+set(unoptimized_sources
+	src/x86_full_empty.c
+)
 
 set(config
 	stinger_names.h
@@ -37,5 +39,6 @@ include_directories("${CMAKE_BINARY_DIR}/include/stinger_core")
 include_directories("${CMAKE_BINARY_DIR}/include/stinger_utils")
 
 set_source_files_properties(${config} PROPERTIES GENERATED TRUE)
-add_library(stinger_core SHARED ${sources} ${headers} ${config})
+set_source_files_properties(${unoptimized_sources} PROPERTIES COMPILE_FLAGS -O0)
+add_library(stinger_core SHARED ${sources} ${unoptimized_sources} ${headers} ${config})
 target_link_libraries(stinger_core compat)


### PR DESCRIPTION
This problem reared its head when trying to do parallel insert in the tests (adamic_adar_test)