### PR TITLE
Fixing stinger_max_active_vertex 

### DIFF
--- a/lib/stinger_core/src/stinger.c
+++ b/lib/stinger_core/src/stinger.c
@@ -273,19 +273,19 @@ stinger_max_num_etypes(stinger_t * S)
  */
 uint64_t
 stinger_max_active_vertex(const struct stinger * S) {
-  uint64_t out = -1;
+  uint64_t out = 0;
   OMP("omp parallel") {
     uint64_t local_max = 0;
     OMP("omp for")
     for(uint64_t i = 0; i < (S->max_nv); i++) {
       if((stinger_indegree_get(S, i) > 0 || stinger_outdegree_get(S, i) > 0) && 
-	i > local_max) {
-	local_max = i;
+        i > local_max) {
+        local_max = i;
       }
     }
     OMP("omp critical") {
       if(local_max > out)
-	out = local_max;
+        out = local_max;
     }
   }
   return out;

--- a/src/clients/algorithms/simple_communities/src/community-update.c
+++ b/src/clients/algorithms/simple_communities/src/community-update.c
@@ -882,7 +882,7 @@ void cstate_preproc_acts (struct community_state * restrict cstate,
 double
 init_cstate_from_stinger (struct community_state * cs, const struct stinger * S)
 {
-  const int64_t nv = stinger_max_active_vertex(S) + 1;
+  const int64_t nv = (stinger_max_active_vertex(S))?stinger_max_active_vertex(S) + 1:0;
   int64_t ne = stinger_max_total_edges(S);
   struct el g = alloc_graph (nv, ne);
   double time = 0;

--- a/src/clients/algorithms/simple_communities/src/simple_communities.c
+++ b/src/clients/algorithms/simple_communities/src/simple_communities.c
@@ -57,7 +57,7 @@ main(int argc, char *argv[])
     return -1;
   }
 
-  nv = stinger_max_active_vertex(alg->stinger)+1;
+  nv = (stinger_max_active_vertex(alg->stinger))?stinger_max_active_vertex(alg->stinger) + 1:0;
   cmap = (int64_t *)alg->alg_data;
 #define UPDATE_EXTERNAL_CMAP(CS) do {                   \
     OMP("omp parallel for")                             \


### PR DESCRIPTION
and updating usage to account for an empty graph case.

I changed this before to have a value of -1 on an empty graph; however, this caused problems because this function returns an unsigned int.  In fact my change broke the function.  A zero value on an empty graph is acceptable as this should always return a value >0 if there is at least one edge in the graph.  I've updated usage in the algorithms to not add 1 to a return value of 0.  This should make it such that algorithms like BC do not fail when there are zero vertices in the graph.